### PR TITLE
Update broken interfaces between py api and next api with FE

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,13 +1,12 @@
-from typing import List
+from typing import Sequence
 
 from fastapi import FastAPI, Query
 from fastapi.responses import StreamingResponse
-from langchain_openai import ChatOpenAI
 from langserve import add_routes
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from .bare import stream_text
-from .config import OPENAI_API_KEY
+from .config import client as lc_openai_client
 from .lc import agent_executor_with_configs
 from .utils.prompt import ClientMessage, convert_to_openai_messages
 
@@ -15,7 +14,10 @@ app = FastAPI()
 
 
 class Request(BaseModel):
-    messages: List[ClientMessage]
+    messages: Sequence[ClientMessage] = Field(
+        ...,
+        examples=[[{"role": "user", "content": "Hello, good morning!"}]],
+    )
 
 
 @app.post("/api/chat")
@@ -32,8 +34,9 @@ async def handle_chat_data(request: Request, protocol: str = Query("data")):
 
 add_routes(
     app=app,
-    runnable=ChatOpenAI(api_key=OPENAI_API_KEY, model="gpt-3.5-turbo", streaming=True),
+    runnable=lc_openai_client,
     path="/api/openai",
+    disabled_endpoints=["config_hashes"],
     # playground_type="chat",
 )
 
@@ -42,5 +45,6 @@ add_routes(
     app=app,
     runnable=agent_executor_with_configs,
     path="/api/agent",
+    disabled_endpoints=["config_hashes"],
     # playground_type="chat",
 )

--- a/api/lc.py
+++ b/api/lc.py
@@ -1,21 +1,20 @@
-from typing import List, Literal, Union
+from typing import Literal, Sequence
 
 from langchain.agents import AgentExecutor, create_tool_calling_agent
-from langchain.pydantic_v1 import BaseModel as BaseModelV1
-from langchain.pydantic_v1 import Field as FieldV1
+from langchain_core.messages import AnyMessage
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
-from pydantic import BaseModel, Field
+from pydantic import BaseModel as BaseModel, Field
 
 from .config import client
 from .utils.tools import _get_current_weather
 
 
-class GetCurrentWeatherParam(BaseModelV1):
-    location: str = FieldV1(description="The city and state, e.g. San Francisco, CA")
-    unit: Literal["celsius", "fahrenheit"] = FieldV1(
+class GetCurrentWeatherParam(BaseModel):
+    location: str = Field(description="The city and state, e.g. San Francisco, CA")
+    unit: Literal["celsius", "fahrenheit"] = Field(
         default="celsius",
         description="The temperature unit to use. Infer this from the users location.",
     )
@@ -56,9 +55,6 @@ prompt = ChatPromptTemplate.from_messages(
 agent = create_tool_calling_agent(client, tools, prompt)
 agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
 
-from langchain_core.messages import AIMessage, FunctionMessage, HumanMessage
-from langchain_core.runnables import RunnableConfig
-
 
 class Input(BaseModel):
     input: str
@@ -68,7 +64,7 @@ class Input(BaseModel):
     # Keep in mind that playground support for agents is not great at the moment.
     # To get a better experience, you'll need to customize the streaming output
     # for now.
-    chat_history: List[Union[HumanMessage, AIMessage, FunctionMessage]] = Field(
+    chat_history: Sequence[AnyMessage] = Field(
         ...,
         extra={"widget": {"type": "chat", "input": "input", "output": "output"}},
     )

--- a/api/ruff.toml
+++ b/api/ruff.toml
@@ -1,0 +1,87 @@
+# Same as Black.
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.12
+target-version = "py312"
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+]
+
+
+[lint]
+# Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
+# Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
+# McCabe complexity (`C901`) by default.
+
+select = ["E4", "E7", "E9", "F", "I"]
+# select = ["ALL"]
+
+# Ignore some rules
+ignore = [
+    "D100",  # Missing docstring in public module
+    "D101",  # Missing docstring in public class
+    "D102",  # Missing docstring in public method
+    "D103",  # Missing docstring in public function
+    "PLR0913",  # Too many arguments in function definition (6 > 5)
+    "SLF001",  # Private member accessed
+    "ANN101",  # Missing type annotation for `self` in method
+    "ERA001",  # Found commented-out code
+    "G004",  # Logging statement uses f-string
+    "T201",  # `print` found
+    "B008",  # for FastAPI
+    "E5",
+    "F401",
+    "F841",
+]
+
+# Allow fix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = ["F401"]
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[lint.isort]
+case-sensitive = true
+combine-as-imports = true

--- a/app/langchain/messages/messageUtil.ts
+++ b/app/langchain/messages/messageUtil.ts
@@ -1,0 +1,7 @@
+import { coerceMessageLikeToMessage, BaseMessageLike } from '@langchain/core/messages'
+import { Message } from 'ai';
+
+export function coerceVercelMessageToLCMessage(message: Message) {
+    const _message: BaseMessageLike = { ...message };
+    return coerceMessageLikeToMessage(_message);
+}

--- a/app/test/agent/route.ts
+++ b/app/test/agent/route.ts
@@ -1,5 +1,7 @@
 import { LangChainAdapter, Message, StreamData } from 'ai';
 import { RemoteRunnable } from "@langchain/core/runnables/remote";
+import { coerceVercelMessageToLCMessage } from '@/app/langchain/messages/messageUtil';
+
 
 
 // Allow streaming responses up to 30 seconds
@@ -16,7 +18,7 @@ export async function POST(req: Request) {
 
   const lastMessage = messages.pop();
   const input = lastMessage?.content;
-  const chatHistory = messages;
+  const chatHistory = messages.map(coerceVercelMessageToLCMessage);
   const payload = {input: input, chat_history: chatHistory};
   console.log("payload: ", payload)
 

--- a/app/test/openai/route.ts
+++ b/app/test/openai/route.ts
@@ -1,6 +1,7 @@
 import { LangChainAdapter, Message } from 'ai';
 import { RemoteRunnable } from "@langchain/core/runnables/remote";
-
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { coerceVercelMessageToLCMessage } from "@/app/langchain/messages/messageUtil"
 
 // Allow streaming responses up to 30 seconds
 export const maxDuration = 30;
@@ -12,13 +13,15 @@ export async function POST(req: Request) {
     messages: Message[];
   } = await req.json();
 
+  const lcMessages = messages.map(coerceVercelMessageToLCMessage);
   console.log("messages: ", messages);
+
 
   const model = new RemoteRunnable({
     url: `http://localhost:8000/api/openai/`,
   });
   // const stream = await model.stream(messages);
-  const stream = await model.streamEvents(messages, {version: "v2"});
+  const stream = await model.streamEvents(lcMessages, { version: "v2" });
 
   console.log("stream: ", stream);
   return LangChainAdapter.toDataStreamResponse(stream);

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-rich==13.7.1
+rich
 python-dotenv
-pydantic<2
 langchain
 langchain-openai
 langchain-community
 langserve[all]
+ruff

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,6 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/types/**/*.ts.bkp"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### TL;DR
Improved type handling and message conversion between LangChain and Vercel AI SDK.

### What changed?
- Replaced `List` with `Sequence` for better type flexibility
- Added message conversion utility (`coerceVercelMessageToLCMessage`)
- Added Ruff configuration for Python code linting
- Updated API endpoints to handle message conversion properly
- Added example schema for chat messages
- Disabled config_hashes endpoints in LangServe routes
- Upgraded dependencies and removed pydantic version constraint

### How to test?
1. Send a chat message through any of the API endpoints (/api/chat, /api/openai, /api/agent)
2. Verify message conversion works correctly between Vercel AI and LangChain
3. Confirm streaming responses are properly formatted
4. Run Ruff linter to ensure code follows new style guidelines

### Why make this change?
To ensure proper type safety and message handling between different SDK implementations, while also improving code quality through consistent linting rules. This change reduces potential runtime errors and makes the codebase more maintainable.